### PR TITLE
Implement proactive notification refresh and fallback polling mechanism

### DIFF
--- a/lib/presentation/pages/auth_wrapper.dart
+++ b/lib/presentation/pages/auth_wrapper.dart
@@ -37,6 +37,36 @@ class _AuthWrapperState extends State<AuthWrapper> {
           message,
           store,
         );
+        // Proactively refresh notifications and counts so UI updates instantly
+        try {
+          final manager = NotificationManager();
+          manager.getNotifications(forceRefresh: true);
+          manager.getNotificationCounts(forceRefresh: true);
+        } catch (_) {}
+      });
+
+      // When user taps a notification from system tray while app is in background
+      FirebaseMessaging.onMessageOpenedApp.listen((
+        RemoteMessage message,
+      ) async {
+        try {
+          final manager = NotificationManager();
+          await manager.getNotifications(forceRefresh: true);
+          await manager.getNotificationCounts(forceRefresh: true);
+        } catch (_) {}
+      });
+
+      // If app was launched by tapping a notification from a terminated state
+      FirebaseMessaging.instance.getInitialMessage().then((
+        RemoteMessage? msg,
+      ) async {
+        if (msg != null) {
+          try {
+            final manager = NotificationManager();
+            await manager.getNotifications(forceRefresh: true);
+            await manager.getNotificationCounts(forceRefresh: true);
+          } catch (_) {}
+        }
       });
     });
   }

--- a/lib/shared/managers/notification_manager.dart
+++ b/lib/shared/managers/notification_manager.dart
@@ -16,6 +16,9 @@ class NotificationManager {
   // Track last known notifications to detect new ones
   List<Notification> _lastKnownNotifications = [];
 
+  // Fallback poller in case realtime is unavailable (e.g., emulator constraints)
+  Timer? _pollTimer;
+
   // Stream controllers
   final StreamController<List<Notification>> _notificationsController =
       StreamController<List<Notification>>.broadcast();
@@ -42,6 +45,7 @@ class NotificationManager {
       _lastKnownNotifications = [];
     }
     _startRealTimeSubscription();
+    _startFallbackPolling();
   }
 
   // Get notifications for current user
@@ -371,5 +375,31 @@ class NotificationManager {
     _notificationsController.close();
     _countsController.close();
     _unreadCountController.close();
+    _pollTimer?.cancel();
+  }
+
+  void _startFallbackPolling() {
+    _pollTimer?.cancel();
+    if (_currentUserId == null) return;
+    _pollTimer = Timer.periodic(const Duration(seconds: 8), (_) async {
+      try {
+        final latest = await _repository.getUserNotifications(
+          userId: _currentUserId!,
+          forceRefresh: true,
+        );
+        // Only emit if changed to avoid redundant rebuilds
+        if (latest.isNotEmpty &&
+            latest.first.id !=
+                (_lastKnownNotifications.isNotEmpty
+                    ? _lastKnownNotifications.first.id
+                    : null)) {
+          _lastKnownNotifications = List.from(latest);
+          _notificationsController.add(latest);
+          _updateCountsFromNotifications(latest);
+        }
+      } catch (_) {
+        // ignore
+      }
+    });
   }
 }


### PR DESCRIPTION
- Added proactive notification and count refresh in AuthWrapper to ensure UI updates instantly.
- Integrated FirebaseMessaging listeners to handle notification taps when the app is in background or terminated state.
- Introduced a fallback polling mechanism in NotificationManager to periodically check for new notifications when real-time updates are unavailable.